### PR TITLE
fix(jazzy-desktop): java dangling symlink

### DIFF
--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -175,3 +175,12 @@ parts:
     override-prime: |
       rm -vf usr/lib/jvm/java-11-openjdk-*/lib/security/blacklisted.certs
 {% endif %}
+{% if ros_distro == 'jazzy' and variant == 'desktop' %}
+  jazzy-desktop-java-cleanup:
+    # https://forum.snapcraft.io/t/resolve-package-contains-external-symlinks-error-when-trying-to-snap/2963/20
+    after: [variant]
+    plugin: nil
+    override-prime: |
+      rm -vf usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts
+{% endif %}
+


### PR DESCRIPTION
Remove the java dangling symlink, producing the following error in `review-tools`:
```
Errors
------
 - lint-snap-v2:external_symlinks
        package contains external symlinks: usr/lib/jvm/java-21-openjdk-amd64/lib/security/cacerts -> /etc/ssl/certs/java/cacerts
```
The file `/etc/ssl/certs/java/cacerts` is missing at install (probably produced by a post-inst script not triggered by snapcraft), this is why snapcraft is not relinking this link.


This is something that already happened in the past: https://github.com/canonical/ros-content-sharing-snaps/blob/main/templates/snapcraft.yaml.j2#L169

I tested that `review-tools` is not detecting anything with the patch locally.