### PR TITLE
ci: rename log file only if the new name is different

### DIFF
--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -93,7 +93,7 @@ jobs:
         run: |
           log_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt')
           for log_file in ${log_files}; do
-            renamed_log_file="${log_file/:/-}"
+            renamed_log_file="${log_file//:/-}"
             if [[ "${log_file}" != "${renamed_log_file}" ]]; then # Only rename if the renamed name is different
               mv -v -n "${log_file}" "${renamed_log_file}"
             fi

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -92,12 +92,10 @@ jobs:
         if: always()
         run: |
           log_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt')
-          for log_file in ${log_files}
-          do
+          for log_file in ${log_files}; do
             renamed_log_file="${log_file/:/-}"
-            if [[ "${log_file}" != "${renamed_log_file}" ]] # Only rename if the renamed name is different
-            then
-              mv -n "${log_file}" "${renamed_log_file}"
+            if [[ "${log_file}" != "${renamed_log_file}" ]]; then # Only rename if the renamed name is different
+              mv -v -n "${log_file}" "${renamed_log_file}"
             fi
           done
       - name: check number of built snaps

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -92,7 +92,14 @@ jobs:
         if: always()
         run: |
           log_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt')
-          for log_file in ${log_files}; do mv -n "${log_file}" "${log_file//:/-}"; done
+          for log_file in ${log_files}
+          do
+            renamed_log_file="${log_file/:/-}"
+            if [[ "${log_file}" != "${renamed_log_file}" ]] # Only rename if the renamed name is different
+            then
+              mv -n "${log_file}" "${renamed_log_file}"
+            fi
+          done
       - name: check number of built snaps
         run: |
           count_txt_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt' | wc -l)


### PR DESCRIPTION
Monthly CI failed due to the renaming part: https://github.com/canonical/ros-content-sharing-snaps/actions/runs/12565334743
The problem was the noetic and foxy (20.04) snapcraft log file didn't contain any ":" hence the renaming with `mv` was failing.