### PR TITLE
add support for ROS 2 Lyrical on core26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ros-content-sharing-snaps
+
 ROS content sharing snaps generator
 
 This repository contains various scripts to generate the content sharing snaps for ROS.
-The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://snapcraft.io/docs/ros-noetic-content-extension) and [ROS 2](https://snapcraft.io/docs/ros2-jazzy-content-extension).
+The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-1-content-extensions/) and [ROS 2](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-content-extensions/).
 
 Additionaly, this repository contains the CI to build and upload the content sharing snaps.
 
@@ -12,10 +13,10 @@ Additionaly, this repository contains the CI to build and upload the content sha
 
 Generate a `package.xml` with all the recursive `build`, `buildtool`, `build_export`, `buildtool_export`, `exec`, `run` and `test` dependencies as exec depends.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
-  --rosdistro {noetic,foxy,humble,jazzy}
+  --rosdistro {noetic,foxy,humble,jazzy,lyrical}
                         The ROS distro to evaluate.
   --variant {desktop,desktop-full,perception,robot,ros-base,ros-core}
                         The ROS (install) metapackage to serve as a variant. (default: None).
@@ -24,14 +25,15 @@ optional arguments:
   -c CMAKE_FILE, --cmake-file CMAKE_FILE
                         CMakeLists.txt file to write for metapackages
 ```
+
 ### generate_ros_meta_snapcraft_file
 
 Generate a `snapcraft.yaml` file for a ROS foundational snap.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
-  -r {noetic,foxy,humble,jazzy}, --rosdistro {noetic,foxy,humble,jazzy}
+  -r {noetic,foxy,humble,jazzy,lyrical}, --rosdistro {noetic,foxy,humble,jazzy,lyrical}
                         The ROS distro to target.
   -v {desktop,desktop-full,perception,robot,ros-base,ros-core}, --variant {desktop,desktop-full,perception,robot,ros-base,ros-core}
                         The ROS metapackage to serve as a baseline. (default: ros-core).
@@ -45,7 +47,7 @@ optional arguments:
 
 Generate a `snapcraft.yaml`` file for all ROS foundational snap.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  Output path for generated files.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ROS content sharing snaps generator
 
 This repository contains various scripts to generate the content sharing snaps for ROS.
-The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-1-content-extensions/) and [ROS 2](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-content-extensions/).
+The Snapcraft extensions corresponding to these content-sharing snaps can be found in the Snapcraft documentation for [ROS](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-1-content-extensions/) and [ROS 2](https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-content-extensions/).
 
 Additionaly, this repository contains the CI to build and upload the content sharing snaps.
 

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -54,6 +54,10 @@ def main(args=None):
             ros_distro = "jazzy",
             variants = ["ros-core", "ros-base", "desktop"],
             architectures = ["amd64", "arm64"]),
+        ROSContentSharingSnapVariants(
+            ros_distro = "lyrical",
+            variants = ["ros-core", "ros-base", "desktop"],
+            architectures = ["amd64", "arm64"]),
         ]
 
     for distro_content_sharing_snap in ros_distros_content_sharing_snaps:

--- a/generate_package_xml_recursive_dependencies.py
+++ b/generate_package_xml_recursive_dependencies.py
@@ -19,7 +19,7 @@ def main():
         "--rosdistro",
         type=str,
         required=True,
-        choices=("noetic", "foxy", "humble", "jazzy"),
+        choices=("noetic", "foxy", "humble", "jazzy", "lyrical"),
         help="The ROS distro to evaluate.",
     )
     parser.add_argument(

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -17,7 +17,7 @@ def main(args=None):
         "--rosdistro",
         type=str,
         required=True,
-        choices=("noetic", "foxy", "humble", "jazzy"),
+        choices=("noetic", "foxy", "humble", "jazzy", "lyrical"),
         help="The ROS distro to target.",
     )
     parser.add_argument(

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -1,12 +1,13 @@
-{%- set coremap={'noetic':'core20', 'foxy':'core20', 'humble':'core22', 'jazzy':'core24'} -%}
-{%- set distromap={'noetic':'focal', 'foxy':'focal', 'humble':'jammy', 'jazzy':'noble'} -%}
-{%- set pluginmap={'noetic':'catkin', 'foxy':'colcon', 'humble':'colcon', 'jazzy':'colcon'} -%}
-{%- set versionmap={'noetic':'1', 'foxy':'2', 'humble':'2', 'jazzy': '2'} -%}
+{%- set coremap={'noetic':'core20', 'foxy':'core20', 'humble':'core22', 'jazzy':'core24', 'lyrical':'core26'} -%}
+{%- set distromap={'noetic':'focal', 'foxy':'focal', 'humble':'jammy', 'jazzy':'noble', 'lyrical':'resolute'} -%}
+{%- set pluginmap={'noetic':'catkin', 'foxy':'colcon', 'humble':'colcon', 'jazzy':'colcon', 'lyrical':'colcon'} -%}
+{%- set versionmap={'noetic':'1', 'foxy':'2', 'humble':'2', 'jazzy': '2', 'lyrical': '2'} -%}
 {%- set slotmap={
   'noetic':["ros-core", "ros-base", "robot", "desktop"],
   'foxy':["ros-core", "ros-base", "desktop"],
   'humble':["ros-core", "ros-base", "desktop"],
   'jazzy':["ros-core", "ros-base", "desktop"],
+  'lyrical':["ros-core", "ros-base", "desktop"],
   }
 -%}
 {%- set ros = 'ros' if versionmap[ros_distro] == '1' else 'ros2' -%}
@@ -73,7 +74,7 @@ package-repositories:
     url: http://packages.ros.org/ros2/ubuntu
 {%- endif %}
 
-{%- if coremap[ros_distro] == "core24" %}
+{%- if coremap[ros_distro] in ["core24", "core26"] %}
 platforms:
   {{ architecture }}:
     build-on: [{{ architecture }}]
@@ -182,5 +183,13 @@ parts:
     plugin: nil
     override-prime: |
       rm -vf usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts
+{% endif %}
+{% if ros_distro == 'lyrical' and variant == 'desktop' %}
+  lyrical-desktop-java-cleanup:
+    # https://forum.snapcraft.io/t/resolve-package-contains-external-symlinks-error-when-trying-to-snap/2963/20
+    after: [variant]
+    plugin: nil
+    override-prime: |
+      rm -vf usr/lib/jvm/java-*-openjdk-*/lib/security/cacerts
 {% endif %}
 


### PR DESCRIPTION
Adds support for generating ROS 2 Lyrical content sharing snaps on core26.

## Changes

- Extended the Jinja2 template maps to include lyrical: core26 as base, resolute as Ubuntu series, colcon as build plugin, ROS 2 as version, and the standard ROS 2 slots (ros-core, ros-base, desktop)

- Updated the platforms: condition to also apply to core26 snaps (previously only triggered for core24)

- Added a lyrical-desktop-java-cleanup part for the desktop variant, using a version-agnostic glob (java-*-openjdk-*) rather than pinning to a specific JDK version — Ubuntu 26.04 ships a newer OpenJDK than 24.04, so hardcoding java-21 would be wrong here

- Added lyrical to the --rosdistro choices in both generator scripts

- Added lyrical to the "generate all" variants list (amd64 + arm64, ros-core/ros-base/desktop)

- Updated the README docs links: the old snapcraft.io/docs URLs no longer exist; replaced with the current documentation.ubuntu.com/snapcraft equivalents, which are single unified pages covering all distros

The CI workflows are distro-agnostic so no workflow changes are needed.

## Testing

- Verified template rendering locally by running the generator scripts against all lyrical variants (ros-core, ros-base, desktop on amd64), and the full generation pipeline via generate_all_ros_meta_snapcraft_file.py. Example test commands:

```
python3 generate_ros_meta_snapcraft_file.py -r lyrical -v ros-core -a amd64
python3 generate_ros_meta_snapcraft_file.py -r lyrical -v ros-base -a amd64
python3 generate_ros_meta_snapcraft_file.py -r lyrical -v desktop -a amd64
```

- Confirmed in the output:

  -   base: core26
  -   suites: [resolute]
  -   platforms: block (not architectures:)
  -   Slots accumulate correctly across variants
  -   lyrical-desktop-java-cleanup part appears only on the desktop variant, using java-*-openjdk-*

- All 12 expected snap folders generated ({ros-core,ros-base,desktop}-{amd64,arm64} + dev variants)

- Existing distros (jazzy, humble) are unaffected

CI remote builds are currently failing because core26 has not yet been published in the store.