### PR TITLE
Feat/migrate to gh runners

### DIFF
--- a/.github/workflows/monthly-builds-esm.yaml
+++ b/.github/workflows/monthly-builds-esm.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   generate-snapcrafts:
     name: Generate snapcraft.yaml files
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
@@ -40,30 +40,17 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
-      - name: Generate snapacraft yaml files for all ros distros
+
+      - name: Generate snapcraft yaml files for all ROS ESM distros
         id: generate
         run: |
           pip install .
           python3 ./generate_all_ros_esm_meta_snapcraft_file.py
-          matrix_json=$(jq -nc '{include: [inputs]}' < <(
-          for dir in snaps/*; do
-            [ -f "$dir/snapcraft.yaml" ] || continue
-            snap_name=$(basename "$dir")
 
-            # Extract build-on architecture
-            arch=$(yq e '.architectures[]."build-on"' "$dir/snapcraft.yaml" | head -n1)
+          # List all snap folders (architecture-free names)
+          matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-            if [ "$arch" = "arm64" ]; then
-              runner='["self-hosted","linux","ARM64","large","noble"]'
-            else
-              runner='["self-hosted","linux","X64","large","noble"]'
-            fi
-
-            jq -nc --arg name "$snap_name" --argjson runner "$runner" \
-              '{snap_name: $name, runner: $runner}'
-          done
-          ))
-          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
       - name: Upload snapcrafts folders
         uses: actions/upload-artifact@v7
         with:
@@ -71,37 +58,40 @@ jobs:
           path: snaps/
 
   snap-build:
-    name: Build ROS ESM snaps
+    name: Build ESM snaps
     needs: generate-snapcrafts
-    env:
-      GH_RUNNER_WORKSPACE_PATH: /home/ubuntu/actions-runner/_work/ros-content-sharing-snaps/ros-content-sharing-snaps
     strategy:
-        fail-fast: false
-        matrix: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
-    runs-on: ${{ matrix.runner }}
+      fail-fast: false
+      matrix:
+        snap_name: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        runs-on: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Download snapcrafts folders
         uses: actions/download-artifact@v8
         with:
           name: snapcraft_yamls
+          path: snaps/
+
       - name: Print snapcraft.yaml
-        run: |
-          cat ${GH_RUNNER_WORKSPACE_PATH}/${{ matrix.snap_name }}/snapcraft.yaml
+        run: cat snaps/${{ matrix.snap_name }}/snapcraft.yaml
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+
       - name: Launch an LXD container
         run: |
-          # TODO: change lxd image based on coreX
-          # currently only 20.04 is supported (Noetic / Foxy)
           lxc launch ubuntu:20.04 lxc-container
           lxc exec lxc-container -- cloud-init status --wait
           until lxc exec lxc-container -- getent passwd ubuntu; do
             echo "Waiting for the ubuntu user."
             sleep 0.25
           done
+
       - name: Push the snap folder to the container
         run: |
-          lxc file push -r ${GH_RUNNER_WORKSPACE_PATH}/${{ matrix.snap_name }}/ lxc-container/home/ubuntu/
+          lxc file push -r snaps/${{ matrix.snap_name }}/ lxc-container/home/ubuntu/
+
       - name: Enable Ubuntu Pro
         env:
           PRO_TOKEN: ${{ secrets.PRO_TOKEN }}
@@ -109,19 +99,27 @@ jobs:
           lxc exec lxc-container -- bash -c "sudo apt update && sudo apt install -y ubuntu-pro-client"
           lxc exec lxc-container -- bash -c "export PRO_TOKEN='$PRO_TOKEN'; sudo pro attach $PRO_TOKEN"
           lxc exec lxc-container -- sudo pro enable ros
+
       - name: Install snapcraft
         run: lxc exec lxc-container -- sudo snap install snapcraft --classic
+
       - name: Run snapcraft
         run: lxc exec lxc-container --cwd /home/ubuntu/${{ matrix.snap_name }} -- sudo snapcraft --destructive-mode
+
+      - name: Get architecture
+        id: get-arch
+        run: echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
+
       - name: Pull snap artifact out of the container
         run: |
           SNAP_FILE=$(lxc exec lxc-container -- bash -c 'ls /home/ubuntu/${{ matrix.snap_name }}/*.snap')
-          lxc file pull lxc-container${SNAP_FILE} ${GH_RUNNER_WORKSPACE_PATH}/${{ matrix.snap_name }}/
-      - name: Upload the snap as artifact
+          lxc file pull "lxc-container${SNAP_FILE}" .
+
+      - name: Upload snap artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.snap_name }}
-          path: ${{ env.GH_RUNNER_WORKSPACE_PATH }}/${{ matrix.snap_name }}/*.snap
+          name: ${{ matrix.snap_name }}-${{ steps.get-arch.outputs.arch }}
+          path: "*.snap"
 
   ros-publish:
     if: github.ref == 'refs/heads/main'
@@ -129,17 +127,21 @@ jobs:
     needs: [generate-snapcrafts, snap-build]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+      matrix:
+        snap_name: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        arch: [amd64, arm64]
     steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: ${{ matrix.snap_name }}
-        path: .
-    - name: Get snap filename
-      run: echo "SNAPFILE=$(ls *.snap)" >> $GITHUB_ENV
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      with:
-        snap: ${{ env.SNAPFILE }}
-        release: beta
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.snap_name }}-${{ matrix.arch }}
+          path: .
+
+      - name: Get snap filename
+        run: echo "SNAPFILE=$(ls *.snap)" >> $GITHUB_ENV
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ env.SNAPFILE }}
+          release: beta

--- a/.github/workflows/monthly-builds-esm.yaml
+++ b/.github/workflows/monthly-builds-esm.yaml
@@ -35,11 +35,9 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Generate snapcraft yaml files for all ROS ESM distros
         id: generate
@@ -77,7 +75,7 @@ jobs:
         run: cat snaps/${{ matrix.snap_name }}/snapcraft.yaml
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@v1
 
       - name: Launch an LXD container
         run: |

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   generate-snapcrafts:
     name: Generate snapcraft.yaml files
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
@@ -40,12 +40,17 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
-      - name: Generate snapacraft yaml files for all ros distros
+
+      - name: Generate snapcraft yaml files for all ROS distros
         id: generate
         run: |
           pip install .
           python3 ./generate_all_ros_meta_snapcraft_file.py
-          echo "matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+          # List all snap folders (architecture-free names)
+          matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
       - name: Upload snapcrafts folders
         uses: actions/upload-artifact@v7
         with:
@@ -53,73 +58,41 @@ jobs:
           path: snaps/
 
   snap-build:
-    name: Remote build ROS snaps
+    name: Build snaps
     needs: generate-snapcrafts
-    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
-        snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        snap_name: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        runs-on: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runs-on }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download snapcrafts folders
         uses: actions/download-artifact@v8
         with:
           name: snapcraft_yamls
-      - name: Add LP credentials
-        run: |
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
-          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
-          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/launchpad-credentials
-          git config --global user.email "canonical-robotics-brand@canonical.com"
-          git config --global user.name "Canonical robotics"
-          git config --global init.defaultBranch main
-          git init /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}
+          path: snaps/
+
       - name: Print snapcraft.yaml
-        run: |
-          cat /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/snapcraft.yaml
-      - name: snapcraft
-        run: |
-          sudo snap install snapcraft --classic
-          cd /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}
-          snapcraft remote-build --launchpad-accept-public-upload
-        # char ':' is illegal in GH artifact naming.
-        # replace it with '-'
-      - name: rename log file
-        if: always()
-        run: |
-          log_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt')
-          for log_file in ${log_files}; do
-            renamed_log_file="${log_file//:/-}"
-            if [[ "${log_file}" != "${renamed_log_file}" ]]; then # Only rename if the renamed name is different
-              mv -v -n "${log_file}" "${renamed_log_file}"
-            fi
-          done
-      - name: check number of built snaps
-        run: |
-          count_txt_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name '*ros*.txt' | wc -l)
-          count_snap_files=$(find ${{ matrix.snap_names }} -type f -name '*.snap' | wc -l)
-          if [ "$count_txt_files" -ne "$count_snap_files" ]; then
-            echo "Error: The number of '.txt' files and '.snap' files do not match."
-            exit 1
-          fi
-      - name: Print snapcraft log
-        if: always()
-        run: |
-          cat /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*ros*.txt
-      - uses: actions/upload-artifact@v7
-        name: Upload snapcraft logs
-        if: always()
+        run: cat snaps/${{ matrix.snap_name }}/snapcraft.yaml
+
+      - name: Build snap
+        uses: canonical/action-build@v1
+        id: build-snap
         with:
-          name: snapcraft_logs_${{ matrix.snap_names }}
-          path: |
-            /home/runner/.cache/snapcraft/log/
-            /home/runner/.local/state/snapcraft/log/
-            /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*ros-*.txt
-      - uses: actions/upload-artifact@v7
-        name: Upload the snap as artifact
+          path: snaps/${{ matrix.snap_name }}
+
+      - name: Get architecture
+        id: get-arch
+        run: echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.snap_names }}
-          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*.snap
+          name: ${{ matrix.snap_name }}-${{ steps.get-arch.outputs.arch }}
+          path: ${{ steps.build-snap.outputs.snap }}
 
   ros-publish:
     if: github.ref == 'refs/heads/main'
@@ -128,18 +101,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        snap_name: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+        arch: [amd64, arm64]
     steps:
-    - uses: actions/download-artifact@v8
-      with:
-        name: ${{ matrix.snap_names }}
-        path: .
-    - name: Get snap filename
-      run: echo "SNAPFILE=$(ls *.snap)" >> $GITHUB_ENV
-    - uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-      with:
-        snap: ${{ env.SNAPFILE }}
-        release: beta
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.snap_name }}-${{ matrix.arch }}
+          path: .
 
+      - name: Get snap filename
+        run: echo "SNAPFILE=$(ls *.snap)" >> $GITHUB_ENV
+
+      - uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ env.SNAPFILE }}
+          release: beta

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -35,11 +35,9 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Generate snapcraft yaml files for all ROS distros
         id: generate
@@ -67,8 +65,6 @@ jobs:
         runs-on: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v6
-
       - name: Download snapcrafts folders
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/promote-snaps.yaml
+++ b/.github/workflows/promote-snaps.yaml
@@ -5,44 +5,34 @@ on:
 
 jobs:
   generate-snap-matrix:
-    name: Generate snapcraft.yaml files
-    runs-on: [ubuntu-latest]
+    name: Generate snap matrix
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+
       - uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-      - name: Generate snapacraft yaml files for all ros distros
+
+      - name: Generate snapcraft yaml files for all ROS distros
         id: generate
         run: |
           pip install .
           python3 ./generate_all_ros_meta_snapcraft_file.py
-          echo "matrix=$(ls snaps/ | sed -e 's/-[a-zA-Z0-9]*$//' | uniq | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          python3 ./generate_all_ros_esm_meta_snapcraft_file.py
+          # List snap folders, exclude -dev variants, prefix with 'ros-' to match store names
+          echo "matrix=$(ls snaps/ | grep -v '\-dev$' | sed 's/^/ros-/' | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
   promote:
-    runs-on: ubuntu-latest
     needs: [generate-snap-matrix]
     strategy:
       fail-fast: false
       matrix:
-        snap_names: ${{ fromJSON(needs.generate-snap-matrix.outputs.matrix) }}
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-    steps:
-      - name: Setup Snapcraft
-        run: |
-          sudo snap install snapcraft --classic
-      - name: Promote ROS snaps to stable
-        run: |
-          snapcraft promote ros-${{ matrix.snap_names }} --from-channel latest/beta --to-channel latest/stable --yes
-      - uses: actions/upload-artifact@v7
-        name: Upload snapcraft logs
-        if: always()
-        with:
-          name: snapcraft_logs_${{ matrix.snap_names }}
-          path: |
-            /home/runner/.local/state/snapcraft/log/
-
+        snap: ${{ fromJSON(needs.generate-snap-matrix.outputs.matrix) }}
+    uses: canonical/robotics-actions-workflows/.github/workflows/promote.yaml@main
+    with:
+      snap: ${{ matrix.snap }}
+      from-channel: latest/beta
+      to-channel: latest/stable
+    secrets:
+      snapstore-login: ${{ secrets.STORE_LOGIN }}

--- a/generate_all_ros_esm_meta_snapcraft_file.py
+++ b/generate_all_ros_esm_meta_snapcraft_file.py
@@ -5,17 +5,20 @@ from typing import List
 
 from generate_ros_meta_snapcraft_file import main as gen
 
+
 class ROSContentSharingSnapVariants:
     """Represent all the content sharing snaps to generate."""
-    def __init__(self, *, ros_distro: str, variants: List[str], architectures: List[str]):
+
+    def __init__(self, *, ros_distro: str, variants: List[str]):
         self.ros_distro = ros_distro
         self.variants = variants
-        self.architectures = architectures
+
 
 def is_dir(path: str) -> Path:
     if os.path.exists(path) and os.path.isdir(path):
         return Path(path)
     raise OSError(f"{path} is not a directory!")
+
 
 def main(args=None):
     parser = argparse.ArgumentParser(
@@ -32,7 +35,7 @@ def main(args=None):
         "-s",
         "--snap",
         help="Run snapcraft for the generated files.",
-        action="store_true"
+        action="store_true",
     )
 
     parsed_args = parser.parse_args(args=args)
@@ -43,29 +46,28 @@ def main(args=None):
 
     ros_distros_content_sharing_snaps = [
         ROSContentSharingSnapVariants(
-            ros_distro = "noetic",
-            variants = ["ros-core", "ros-base", "robot", "desktop"],
-            architectures = ["amd64", "arm64"]),
-        ]
+            ros_distro="noetic",
+            variants=["ros-core", "ros-base", "robot", "desktop"],
+        ),
+    ]
 
     for distro_content_sharing_snap in ros_distros_content_sharing_snaps:
         for variant in distro_content_sharing_snap.variants:
-            for architecture in distro_content_sharing_snap.architectures:
-                ros_distro = distro_content_sharing_snap.ros_distro
-                folders = [
-                    parsed_args.path / f'{ros_distro}-{variant}-{architecture}',
-                    parsed_args.path / f'{ros_distro}-{variant}-dev-{architecture}'
-                ]
+            ros_distro = distro_content_sharing_snap.ros_distro
+            folders = [
+                parsed_args.path / f"{ros_distro}-{variant}",
+                parsed_args.path / f"{ros_distro}-{variant}-dev",
+            ]
 
-                for folder in folders:
-                    os.makedirs(folder, exist_ok=True)
-                    gen_args = ["-r", ros_distro, "-v", variant, "-a", architecture, "-p", str(folder), "-q"]
-                    if "dev" in folder.stem:
-                        gen_args.append("-d")
-                    if parsed_args.snap:
-                        gen_args.append("-s")
+            for folder in folders:
+                os.makedirs(folder, exist_ok=True)
+                gen_args = ["-r", ros_distro, "-v", variant, "-p", str(folder), "-q"]
+                if "dev" in folder.stem:
+                    gen_args.append("-d")
+                if parsed_args.snap:
+                    gen_args.append("-s")
 
-                    gen(gen_args)
+                gen(gen_args)
 
 
 if __name__ == "__main__":

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -5,17 +5,20 @@ from typing import List
 
 from generate_ros_meta_snapcraft_file import main as gen
 
+
 class ROSContentSharingSnapVariants:
     """Represent all the content sharing snaps to generate."""
-    def __init__(self, *, ros_distro: str, variants: List[str], architectures: List[str]):
+
+    def __init__(self, *, ros_distro: str, variants: List[str]):
         self.ros_distro = ros_distro
         self.variants = variants
-        self.architectures = architectures
+
 
 def is_dir(path: str) -> Path:
     if os.path.exists(path) and os.path.isdir(path):
         return Path(path)
     raise OSError(f"{path} is not a directory!")
+
 
 def main(args=None):
     parser = argparse.ArgumentParser(
@@ -32,7 +35,7 @@ def main(args=None):
         "-s",
         "--snap",
         help="Run snapcraft for the generated files.",
-        action="store_true"
+        action="store_true",
     )
 
     parsed_args = parser.parse_args(args=args)
@@ -43,37 +46,33 @@ def main(args=None):
 
     ros_distros_content_sharing_snaps = [
         ROSContentSharingSnapVariants(
-            ros_distro = "foxy",
-            variants = ["ros-core", "ros-base", "desktop"],
-            architectures = ["amd64", "arm64"]),
+            ros_distro="foxy", variants=["ros-core", "ros-base", "desktop"]
+        ),
         ROSContentSharingSnapVariants(
-            ros_distro = "humble",
-            variants = ["ros-core", "ros-base", "desktop"],
-            architectures = ["amd64", "arm64"]),
+            ros_distro="humble", variants=["ros-core", "ros-base", "desktop"]
+        ),
         ROSContentSharingSnapVariants(
-            ros_distro = "jazzy",
-            variants = ["ros-core", "ros-base", "desktop"],
-            architectures = ["amd64", "arm64"]),
-        ]
+            ros_distro="jazzy", variants=["ros-core", "ros-base", "desktop"]
+        ),
+    ]
 
     for distro_content_sharing_snap in ros_distros_content_sharing_snaps:
         for variant in distro_content_sharing_snap.variants:
-            for architecture in distro_content_sharing_snap.architectures:
-                ros_distro = distro_content_sharing_snap.ros_distro
-                folders = [
-                    parsed_args.path / f'{ros_distro}-{variant}-{architecture}',
-                    parsed_args.path / f'{ros_distro}-{variant}-dev-{architecture}'
-                ]
+            ros_distro = distro_content_sharing_snap.ros_distro
+            folders = [
+                parsed_args.path / f"{ros_distro}-{variant}",
+                parsed_args.path / f"{ros_distro}-{variant}-dev",
+            ]
 
-                for folder in folders:
-                    os.makedirs(folder, exist_ok=True)
-                    gen_args = ["-r", ros_distro, "-v", variant, "-a", architecture, "-p", str(folder), "-q"]
-                    if "dev" in folder.stem:
-                        gen_args.append("-d")
-                    if parsed_args.snap:
-                        gen_args.append("-s")
+            for folder in folders:
+                os.makedirs(folder, exist_ok=True)
+                gen_args = ["-r", ros_distro, "-v", variant, "-p", str(folder), "-q"]
+                if "dev" in folder.stem:
+                    gen_args.append("-d")
+                if parsed_args.snap:
+                    gen_args.append("-s")
 
-                    gen(gen_args)
+                gen(gen_args)
 
 
 if __name__ == "__main__":

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -37,14 +37,6 @@ def main(args=None):
         help="The ROS metapackage to serve as a baseline. (default: %(default)s).",
     )
     parser.add_argument(
-        "-a",
-        "--architecture",
-        type=str,
-        required=False,
-        choices=("amd64", "arm64", "armhf"),
-        help="Deprecated. Architecture is no longer used in template generation.",
-    )
-    parser.add_argument(
         "-p",
         "--path",
         # type=is_dir,

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -40,9 +40,9 @@ def main(args=None):
         "-a",
         "--architecture",
         type=str,
-        required=True,
+        required=False,
         choices=("amd64", "arm64", "armhf"),
-        help="The snap architecture to target.",
+        help="Deprecated. Architecture is no longer used in template generation.",
     )
     parser.add_argument(
         "-p",
@@ -52,9 +52,7 @@ def main(args=None):
         # default="",
         help="Output path for generated files.",
     )
-    parser.add_argument(
-        "-s", "--snap", help="Run snapcraft.", action="store_true"
-    )
+    parser.add_argument("-s", "--snap", help="Run snapcraft.", action="store_true")
     parser.add_argument(
         "-d", "--dev", help="Generate the dev snap.", action="store_true"
     )
@@ -70,32 +68,36 @@ def main(args=None):
 
     with open(Path("templates") / template_name, "r") as f:
         environment = jinja2.Environment()
-        environment.filters['bool']= bool
+        environment.filters["bool"] = bool
         template = environment.from_string(f.read())
         snapcraft_file = template.render(
-            ros_distro = parsed_args.rosdistro,
-            architecture = parsed_args.architecture,
-            variant = parsed_args.variant,
-            dev = parsed_args.dev,
+            ros_distro=parsed_args.rosdistro,
+            variant=parsed_args.variant,
+            dev=parsed_args.dev,
         )
-        if not parsed_args.quiet: print(snapcraft_file)
+        if not parsed_args.quiet:
+            print(snapcraft_file)
         if parsed_args.path:
-            if not (os.path.exists(parsed_args.path) and os.path.isdir(parsed_args.path)):
+            if not (
+                os.path.exists(parsed_args.path) and os.path.isdir(parsed_args.path)
+            ):
                 raise IsADirectoryError(f"{parsed_args.path} is not a directory!")
             with open(Path(parsed_args.path) / "snapcraft.yaml", "w") as f:
                 f.write(snapcraft_file)
             if parsed_args.snap:
                 subprocess.run(
-                    ["snapcraft", "--use-lxd", "--verbose"], check=True,
+                    ["snapcraft", "--use-lxd", "--verbose"],
+                    check=True,
                 )
 
         # add the generate_package_xml_recursive_dependencies.py in case of a dev snap
         if parsed_args.dev:
-            shutil.copy2("generate_package_xml_recursive_dependencies.py", f"{parsed_args.path}")
+            shutil.copy2(
+                "generate_package_xml_recursive_dependencies.py", f"{parsed_args.path}"
+            )
 
         return snapcraft_file
 
 
 if __name__ == "__main__":
     main()
-

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -75,12 +75,12 @@ package-repositories:
 
 {%- if coremap[ros_distro] == "core24" %}
 platforms:
-  {{ architecture }}:
-    build-on: [{{ architecture }}]
-    build-for: [{{ architecture }}]
-{%- else %}
-architectures:
-  - build-on: {{ architecture }}
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
 {%- endif %}
 
 {% if dev is not defined or not dev | bool -%}


### PR DESCRIPTION
GH has introduced GH runners for arm64.

We can now build all our ros-content-sharing snaps with the GH public runners.

Previously we had to generate one snapcraft.yaml per architecture. This was due to a limitation in the Launchpad remote-build.

I got rid of the per arch `snapcraft.yaml` since we can now use the amd64 and arm64 runner on the same `snapcraft.yaml`.