### PR TITLE
Add content sharing lyrical support 

### DIFF
--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -80,10 +80,10 @@ jobs:
           if [[ "${{ matrix.snap_name }}" == *foxy* ]]; then
             echo "channel=8.x/stable" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.snap_name }}" == *lyrical* ]]; then
-            # core26 support is only available in snapcraft 9's edge channel for now.
-            # The core26 support landed after 9.0.0 (candidate/stable) was cut, so
-            # use 9.x/edge for lyrical until it is promoted to a stable channel.
-            echo "channel=9.x/edge" >> $GITHUB_OUTPUT
+            # core26 support is only available in snapcraft 9's latest edge channel for now.
+            # The core26 support landed after 9.0.0, so
+            # use latest/edge for lyrical it lands to 9.x stable channel.
+            echo "channel=latest/edge" >> $GITHUB_OUTPUT
           else
             echo "channel=latest/stable" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -88,8 +88,9 @@ jobs:
         id: build-snap
         with:
           path: snaps/${{ matrix.snap_name }}
+          # To have core26 stable snapcraft 9 is needed, but it is not yet available in latest/stable.
+          # Hence for now we use 9.x/candidate for lyrical until it is promoted to latest/stable.
           snapcraft-channel: ${{ startsWith(matrix.snap_name, 'lyrical-') && '9.x/candidate' || 'latest/stable' }}
-
       - name: Get architecture
         id: get-arch
         run: echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -79,6 +79,10 @@ jobs:
         run: |
           if [[ "${{ matrix.snap_name }}" == *foxy* ]]; then
             echo "channel=8.x/stable" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.snap_name }}" == *lyrical* ]]; then
+            # To have core26 stable snapcraft 9 is needed, but it is not yet available in latest/stable.
+            # Hence for now we use 9.x/candidate for lyrical until it is promoted to latest/stable.
+            echo "channel=9.x/candidate" >> $GITHUB_OUTPUT
           else
             echo "channel=latest/stable" >> $GITHUB_OUTPUT
           fi
@@ -88,9 +92,7 @@ jobs:
         id: build-snap
         with:
           path: snaps/${{ matrix.snap_name }}
-          # To have core26 stable snapcraft 9 is needed, but it is not yet available in latest/stable.
-          # Hence for now we use 9.x/candidate for lyrical until it is promoted to latest/stable.
-          snapcraft-channel: ${{ startsWith(matrix.snap_name, 'lyrical-') && '9.x/candidate' || 'latest/stable' }}
+          snapcraft-channel: ${{ steps.snapcraft.outputs.channel }}
       - name: Get architecture
         id: get-arch
         run: echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -88,7 +88,7 @@ jobs:
         id: build-snap
         with:
           path: snaps/${{ matrix.snap_name }}
-          snapcraft-channel: ${{ steps.snapcraft.outputs.channel }}
+          snapcraft-channel: ${{ startsWith(matrix.snap_name, 'lyrical-') && '9.x/candidate' || 'latest/stable' }}
 
       - name: Get architecture
         id: get-arch

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -80,9 +80,10 @@ jobs:
           if [[ "${{ matrix.snap_name }}" == *foxy* ]]; then
             echo "channel=8.x/stable" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.snap_name }}" == *lyrical* ]]; then
-            # To have core26 stable snapcraft 9 is needed, but it is not yet available in latest/stable.
-            # Hence for now we use 9.x/candidate for lyrical until it is promoted to latest/stable.
-            echo "channel=9.x/candidate" >> $GITHUB_OUTPUT
+            # core26 support is only available in snapcraft 9's edge channel for now.
+            # The core26 support landed after 9.0.0 (candidate/stable) was cut, so
+            # use 9.x/edge for lyrical until it is promoted to a stable channel.
+            echo "channel=9.x/edge" >> $GITHUB_OUTPUT
           else
             echo "channel=latest/stable" >> $GITHUB_OUTPUT
           fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ros-content-sharing-snaps
+
 ROS content sharing snaps generator
 
 This repository contains various scripts to generate the content sharing snaps for ROS.
-The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://snapcraft.io/docs/ros-noetic-content-extension) and [ROS 2](https://snapcraft.io/docs/ros2-jazzy-content-extension).
+The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://snapcraft.io/docs/ros-noetic-content-extension) and [ROS 2](https://snapcraft.io/docs/ros2-lyrical-content-extension).
 
 Additionaly, this repository contains the CI to build and upload the content sharing snaps.
 
@@ -14,10 +15,10 @@ All generated snaps include the `ros_snapd_interfaces` package from https://gith
 
 Generate a `package.xml` with all the recursive `build`, `buildtool`, `build_export`, `buildtool_export`, `exec`, `run` and `test` dependencies as exec depends.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
-  --rosdistro {noetic,foxy,humble,jazzy}
+  --rosdistro {noetic,foxy,humble,jazzy,lyrical}
                         The ROS distro to evaluate.
   --variant {desktop,desktop-full,perception,robot,ros-base,ros-core}
                         The ROS (install) metapackage to serve as a variant. (default: None).
@@ -26,14 +27,15 @@ optional arguments:
   -c CMAKE_FILE, --cmake-file CMAKE_FILE
                         CMakeLists.txt file to write for metapackages
 ```
+
 ### generate_ros_meta_snapcraft_file
 
 Generate a `snapcraft.yaml` file for a ROS foundational snap.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
-  -r {noetic,foxy,humble,jazzy}, --rosdistro {noetic,foxy,humble,jazzy}
+  -r {noetic,foxy,humble,jazzy,lyrical}, --rosdistro {noetic,foxy,humble,jazzy,lyrical}
                         The ROS distro to target.
   -v {desktop,desktop-full,perception,robot,ros-base,ros-core}, --variant {desktop,desktop-full,perception,robot,ros-base,ros-core}
                         The ROS metapackage to serve as a baseline. (default: ros-core).
@@ -47,7 +49,7 @@ optional arguments:
 
 Generate a `snapcraft.yaml`` file for all ROS foundational snap.
 
-```
+```console
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  Output path for generated files.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ROS content sharing snaps generator
 This repository contains various scripts to generate the content sharing snaps for ROS.
 The snapcraft extensions corresponding to these content-sharing can be found the snapcraft documentation for [ROS](https://snapcraft.io/docs/ros-noetic-content-extension) and [ROS 2](https://snapcraft.io/docs/ros2-lyrical-content-extension).
 
-Additionaly, this repository contains the CI to build and upload the content sharing snaps.
+Additionally, this repository contains the CI to build and upload the content sharing snaps.
 
 All generated snaps include the `ros_snapd_interfaces` package from https://github.com/canonical/ros_snapd_interfaces.
 
@@ -47,7 +47,7 @@ optional arguments:
 
 ### generate_all_ros_meta_snapcraft_file
 
-Generate a `snapcraft.yaml`` file for all ROS foundational snap.
+Generate a `snapcraft.yaml` file for all ROS foundational snap.
 
 ```console
 optional arguments:

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -54,6 +54,9 @@ def main(args=None):
         ROSContentSharingSnapVariants(
             ros_distro="jazzy", variants=["ros-core", "ros-base", "desktop"]
         ),
+        ROSContentSharingSnapVariants(
+            ros_distro="lyrical", variants=["ros-core", "ros-base", "desktop"]
+        ),
     ]
 
     for distro_content_sharing_snap in ros_distros_content_sharing_snaps:

--- a/generate_package_xml_recursive_dependencies.py
+++ b/generate_package_xml_recursive_dependencies.py
@@ -38,6 +38,12 @@ def get_latest_rosdistro_tag(rosdistro_name: str) -> str:
         if "^{}" not in line
     ]
     if not tags:
+        if rosdistro_name == "lyrical":
+            print(
+                "No lyrical tag found in ros/rosdistro, using master index-v4.yaml "
+                "temporarily (lyrical/distribution.yaml)."
+            )
+            return "master"
         raise RuntimeError(f"No tag found for '{rosdistro_name}' in ros/rosdistro")
     return tags[-1]
 
@@ -84,7 +90,8 @@ def main():
 
     args = parser.parse_args()
 
-    # We get the index from the latest tag and not from master which is not synced
+    # We get the index from the latest tag and not from master which is not synced.
+    # For lyrical (not tagged yet), get_latest_rosdistro_tag falls back to "master".
     latest_tag = get_latest_rosdistro_tag(args.rosdistro)
     index = rosdistro.get_index(
         f"https://raw.githubusercontent.com/ros/rosdistro/{latest_tag}/index-v4.yaml"

--- a/generate_package_xml_recursive_dependencies.py
+++ b/generate_package_xml_recursive_dependencies.py
@@ -50,7 +50,7 @@ def main():
         "--rosdistro",
         type=str,
         required=True,
-        choices=("noetic", "foxy", "humble", "jazzy"),
+        choices=("noetic", "foxy", "humble", "jazzy", "lyrical"),
         help="The ROS distro to evaluate.",
     )
     parser.add_argument(

--- a/generate_package_xml_recursive_dependencies.py
+++ b/generate_package_xml_recursive_dependencies.py
@@ -38,12 +38,6 @@ def get_latest_rosdistro_tag(rosdistro_name: str) -> str:
         if "^{}" not in line
     ]
     if not tags:
-        if rosdistro_name == "lyrical":
-            print(
-                "No lyrical tag found in ros/rosdistro, using master index-v4.yaml "
-                "temporarily (lyrical/distribution.yaml)."
-            )
-            return "master"
         raise RuntimeError(f"No tag found for '{rosdistro_name}' in ros/rosdistro")
     return tags[-1]
 
@@ -90,8 +84,7 @@ def main():
 
     args = parser.parse_args()
 
-    # We get the index from the latest tag and not from master which is not synced.
-    # For lyrical (not tagged yet), get_latest_rosdistro_tag falls back to "master".
+    # We get the index from the latest tag
     latest_tag = get_latest_rosdistro_tag(args.rosdistro)
     index = rosdistro.get_index(
         f"https://raw.githubusercontent.com/ros/rosdistro/{latest_tag}/index-v4.yaml"

--- a/generate_package_xml_recursive_dependencies.py
+++ b/generate_package_xml_recursive_dependencies.py
@@ -84,7 +84,7 @@ def main():
 
     args = parser.parse_args()
 
-    # We get the index from the latest tag
+    # We get the index from the latest tag and not from master which is not synced
     latest_tag = get_latest_rosdistro_tag(args.rosdistro)
     index = rosdistro.get_index(
         f"https://raw.githubusercontent.com/ros/rosdistro/{latest_tag}/index-v4.yaml"

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -17,7 +17,7 @@ def main(args=None):
         "--rosdistro",
         type=str,
         required=True,
-        choices=("noetic", "foxy", "humble", "jazzy"),
+        choices=("noetic", "foxy", "humble", "jazzy", "lyrical"),
         help="The ROS distro to target.",
     )
     parser.add_argument(

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -240,6 +240,5 @@ parts:
     after: [variant]
     plugin: nil
     override-prime: |
-      rm -vf usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts
+      rm -vf usr/lib/jvm/java-25-openjdk-*/lib/security/cacerts
 {% endif %}
-

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -1,12 +1,13 @@
-{%- set coremap={'noetic':'core20', 'foxy':'core20', 'humble':'core22', 'jazzy':'core24'} -%}
-{%- set distromap={'noetic':'focal', 'foxy':'focal', 'humble':'jammy', 'jazzy':'noble'} -%}
-{%- set pluginmap={'noetic':'catkin', 'foxy':'colcon', 'humble':'colcon', 'jazzy':'colcon'} -%}
-{%- set versionmap={'noetic':'1', 'foxy':'2', 'humble':'2', 'jazzy': '2'} -%}
+{%- set coremap={'noetic':'core20', 'foxy':'core20', 'humble':'core22', 'jazzy':'core24', 'lyrical':'core26'} -%}
+{%- set distromap={'noetic':'focal', 'foxy':'focal', 'humble':'jammy', 'jazzy':'noble', 'lyrical':'resolute'} -%}
+{%- set pluginmap={'noetic':'catkin', 'foxy':'colcon', 'humble':'colcon', 'jazzy':'colcon', 'lyrical':'colcon'} -%}
+{%- set versionmap={'noetic':'1', 'foxy':'2', 'humble':'2', 'jazzy': '2', 'lyrical': '2'} -%}
 {%- set slotmap={
   'noetic':["ros-core", "ros-base", "robot", "desktop"],
   'foxy':["ros-core", "ros-base", "desktop"],
   'humble':["ros-core", "ros-base", "desktop"],
   'jazzy':["ros-core", "ros-base", "desktop"],
+  'lyrical':["ros-core", "ros-base", "desktop"],
   }
 -%}
 {%- set ros = 'ros' if versionmap[ros_distro] == '1' else 'ros2' -%}
@@ -73,7 +74,7 @@ package-repositories:
     url: http://packages.ros.org/ros2/ubuntu
 {%- endif %}
 
-{%- if coremap[ros_distro] == "core24" %}
+{%- if coremap[ros_distro] in ["core24", "core26"] %}
 platforms:
   amd64:
     build-on: [amd64]
@@ -212,3 +213,12 @@ parts:
     override-prime: |
       rm -vf usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts
 {% endif %}
+{% if ros_distro == 'lyrical' and variant == 'desktop' %}
+  lyrical-desktop-java-cleanup:
+    # https://forum.snapcraft.io/t/resolve-package-contains-external-symlinks-error-when-trying-to-snap/2963/20
+    after: [variant]
+    plugin: nil
+    override-prime: |
+      rm -vf usr/lib/jvm/java-21-openjdk-*/lib/security/cacerts
+{% endif %}
+

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -131,21 +131,12 @@ parts:
     # core26 do not ship python3; stage enough of the
     # interpreter for the ROS python stack to run.
     stage-packages:
-      - python3-minimal       # for the "python3" symlink
-      - python3.14-minimal
-      - libpython3.14-stdlib
       - python3-catkin-pkg    # required by ament_cmake_core at build time
 {%- endif %}
 {%- if versionmap[ros_distro] == '1' %}
     build-packages: [build-essential, ros-{{ ros_distro }}-catkin]
 {%- else %}
     build-packages:
-{%- if ros_distro == 'lyrical' %}
-      # Required by generate_package_xml_recursive_dependencies.py
-      - python3-catkin-pkg
-      - python3-rosdistro
-      - python3-rosdistro-modules
-{%- endif %}
       - ros-{{ ros_distro }}-ros-environment
       - ros-{{ ros_distro }}-ros-workspace
       - ros-{{ ros_distro }}-ament-index-cpp

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -127,16 +127,15 @@ parts:
   variant:
     plugin: {{ pluginmap[ros_distro] }}
     source: .
-{%- if ros_distro == 'lyrical' %}
-    # core26 do not ship python3; stage enough of the
-    # interpreter for the ROS python stack to run.
-    stage-packages:
-      - python3-catkin-pkg    # required by ament_cmake_core at build time
-{%- endif %}
 {%- if versionmap[ros_distro] == '1' %}
     build-packages: [build-essential, ros-{{ ros_distro }}-catkin]
 {%- else %}
     build-packages:
+      # Required by generate_package_xml_recursive_dependencies.py
+      # in override-build. The colcon plugin
+      # pulls them in transitively, but we list them here explicitly.
+      - python3-catkin-pkg-modules
+      - python3-rosdistro-modules
       - ros-{{ ros_distro }}-ros-environment
       - ros-{{ ros_distro }}-ros-workspace
       - ros-{{ ros_distro }}-ament-index-cpp

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -127,10 +127,31 @@ parts:
   variant:
     plugin: {{ pluginmap[ros_distro] }}
     source: .
+<<<<<<< HEAD
+=======
+{%- if ros_distro == 'lyrical' %}
+    stage-packages:
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal # for the "python3" symlink
+      - python3.14-minimal
+      - python3.14-venv
+      - python3-catkin-pkg
+      - python3-yaml
+{%- endif %}
+>>>>>>> 976dc31 (add fallback to generate package.xml for lyrical since is not tagged, add python deps)
 {%- if versionmap[ros_distro] == '1' %}
-    build-packages: [build-essential, ros-{{ ros_distro }}-catkin]
+    build-packages:
+      - build-essential
+      - python3-catkin-pkg
+      - python3-rosdistro
+      - python3-rosdistro-modules
+      - ros-{{ ros_distro }}-catkin
 {%- else %}
     build-packages:
+      - python3-catkin-pkg
+      - python3-rosdistro
+      - python3-rosdistro-modules
       - ros-{{ ros_distro }}-ros-environment
       - ros-{{ ros_distro }}-ros-workspace
       - ros-{{ ros_distro }}-ament-index-cpp
@@ -140,7 +161,7 @@ parts:
       - ROS_DISTRO: {{ ros_distro }}
       - ROS_VERSION: '{{ versionmap[ros_distro] }}'
     override-build: |
-      python3 $SNAPCRAFT_PART_SRC/generate_package_xml_recursive_dependencies.py --variant {{ variant }} --rosdistro $ROS_DISTRO --output-file $SNAPCRAFT_PART_SRC/package.xml --cmake-file $SNAPCRAFT_PART_SRC/CMakeLists.txt
+      /usr/bin/python3 $SNAPCRAFT_PART_SRC/generate_package_xml_recursive_dependencies.py --variant {{ variant }} --rosdistro $ROS_DISTRO --output-file $SNAPCRAFT_PART_SRC/package.xml --cmake-file $SNAPCRAFT_PART_SRC/CMakeLists.txt
 {% if coremap[ros_distro] == 'core20' %}
       snapcraftctl build
 {% else %}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -127,31 +127,25 @@ parts:
   variant:
     plugin: {{ pluginmap[ros_distro] }}
     source: .
-<<<<<<< HEAD
-=======
 {%- if ros_distro == 'lyrical' %}
+    # core26 do not ship python3; stage enough of the
+    # interpreter for the ROS python stack to run.
     stage-packages:
-      - libpython3.14-minimal
-      - libpython3.14-stdlib
-      - python3-minimal # for the "python3" symlink
+      - python3-minimal       # for the "python3" symlink
       - python3.14-minimal
-      - python3.14-venv
-      - python3-catkin-pkg
-      - python3-yaml
+      - libpython3.14-stdlib
+      - python3-catkin-pkg    # required by ament_cmake_core at build time
 {%- endif %}
->>>>>>> 976dc31 (add fallback to generate package.xml for lyrical since is not tagged, add python deps)
 {%- if versionmap[ros_distro] == '1' %}
-    build-packages:
-      - build-essential
-      - python3-catkin-pkg
-      - python3-rosdistro
-      - python3-rosdistro-modules
-      - ros-{{ ros_distro }}-catkin
+    build-packages: [build-essential, ros-{{ ros_distro }}-catkin]
 {%- else %}
     build-packages:
+{%- if ros_distro == 'lyrical' %}
+      # Required by generate_package_xml_recursive_dependencies.py
       - python3-catkin-pkg
       - python3-rosdistro
       - python3-rosdistro-modules
+{%- endif %}
       - ros-{{ ros_distro }}-ros-environment
       - ros-{{ ros_distro }}-ros-workspace
       - ros-{{ ros_distro }}-ament-index-cpp
@@ -175,7 +169,15 @@ parts:
 {% else %}
   variant:
     plugin: nil
-    stage-packages: [ros-{{ ros_distro }}-{{ variant | replace("_", "-") }}]
+    stage-packages:
+      - ros-{{ ros_distro }}-{{ variant | replace("_", "-") }}
+{%- if ros_distro == 'lyrical' %}
+      # core26 do not ship python3; stage enough of the
+      # interpreter for the ROS python stack to run.
+      - python3-minimal       # for the "python3" symlink
+      - python3.14-minimal    # interpreter (pulls libpython3.14-minimal)
+      - libpython3.14-stdlib  # stdlib (encodings, json, ...)
+{%- endif %}
     after: [ros-snapd-interfaces]
     # deb's update-alternatives are not run in snapcraft,
     # thus these libraries symlinks aren't create in lib/arch/.

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -161,13 +161,6 @@ parts:
     plugin: nil
     stage-packages:
       - ros-{{ ros_distro }}-{{ variant | replace("_", "-") }}
-{%- if ros_distro == 'lyrical' %}
-      # core26 do not ship python3; stage enough of the
-      # interpreter for the ROS python stack to run.
-      - python3-minimal       # for the "python3" symlink
-      - python3.14-minimal    # interpreter (pulls libpython3.14-minimal)
-      - libpython3.14-stdlib  # stdlib (encodings, json, ...)
-{%- endif %}
     after: [ros-snapd-interfaces]
     # deb's update-alternatives are not run in snapcraft,
     # thus these libraries symlinks aren't create in lib/arch/.


### PR DESCRIPTION
This PR adds support for ROS 2 Lyrical content sharing snaps with Core26.
It requires https://github.com/canonical/snapcraft/pull/6053 to be merged for the build to work.